### PR TITLE
Add "admin notice" instead of exception

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -23,9 +23,11 @@ if (!function_exists('pll_translations')) {
     function pll_translations(array $groups, $multiline = false)
     {
         if (!function_exists('pll_register_string')) {
-            add_action('admin_notices', function () {
-                printf('<div class="notice notice-error"><p>Please <a href="%s">activate</a> the Polylang plugin and configure it with at least one <a href="%s">language</a>.</p></div>', admin_url('plugins.php'), admin_url('admin.php?page=mlang'));
-            });
+            if (function_exists('add_action')) {
+                add_action('admin_notices', function () {
+                    printf('<div class="notice notice-error"><p>Please <a href="%s">activate</a> the Polylang plugin and configure it with at least one <a href="%s">language</a>.</p></div>', admin_url('plugins.php'), admin_url('admin.php?page=mlang'));
+                });
+            }
         } else {
             foreach ($groups as $group => $translations) {
                 foreach ($translations as $key => $description) {
@@ -48,9 +50,11 @@ if (!function_exists('trans')) {
     function trans(string $key, string $lang = null): string
     {
         if (!function_exists('pll__') || !function_exists('pll_translate_string')) {
-            add_action('admin_notices', function () {
-                printf('<div class="notice notice-error"><p>Please <a href="%s">activate</a> the Polylang plugin and configure it with at least one <a href="%s">language</a>.</p></div>', admin_url('plugins.php'), admin_url('admin.php?page=mlang'));
-            });
+            if (function_exists('add_action')) {
+                add_action('admin_notices', function () {
+                    printf('<div class="notice notice-error"><p>Please <a href="%s">activate</a> the Polylang plugin and configure it with at least one <a href="%s">language</a>.</p></div>', admin_url('plugins.php'), admin_url('admin.php?page=mlang'));
+                });
+            }
         }
 
         if (function_exists('pll_translate_string') && $lang) {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -23,7 +23,7 @@ if (!function_exists('pll_translations')) {
     function pll_translations(array $groups, $multiline = false)
     {
         if (!function_exists('pll_register_string')) {
-            add_action('admin_notices', function() {
+            add_action('admin_notices', function () {
                 printf('<div class="notice notice-error"><p>Please <a href="%s">activate</a> the Polylang plugin and configure it with at least one <a href="%s">language</a>.</p></div>', admin_url('plugins.php'), admin_url('admin.php?page=mlang'));
             });
         } else {
@@ -48,7 +48,7 @@ if (!function_exists('trans')) {
     function trans(string $key, string $lang = null): string
     {
         if (!function_exists('pll__') || !function_exists('pll_translate_string')) {
-            add_action('admin_notices', function() {
+            add_action('admin_notices', function () {
                 printf('<div class="notice notice-error"><p>Please <a href="%s">activate</a> the Polylang plugin and configure it with at least one <a href="%s">language</a>.</p></div>', admin_url('plugins.php'), admin_url('admin.php?page=mlang'));
             });
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -68,7 +68,7 @@ if (!function_exists('trans')) {
         if (function_exists('__')) {
             return __($key);
         }
-        
+
         return $key;
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -65,6 +65,10 @@ if (!function_exists('trans')) {
             return pll__($key);
         }
 
-        return __($key);
+        if (function_exists('__')) {
+            return __($key);
+        }
+        
+        return $key;
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,19 +18,19 @@ if (!function_exists('pll_translations')) {
      * @param array $groups
      * @param bool $multiline
      *
-     * @throws \BadFunctionCallException
-     *
      * @return void
      */
     function pll_translations(array $groups, $multiline = false)
     {
         if (!function_exists('pll_register_string')) {
-            throw new BadFunctionCallException('Please activate the Polylang plugin and configure it with at least one language.');
-        }
-
-        foreach ($groups as $group => $translations) {
-            foreach ($translations as $key => $description) {
-                pll_register_string($description, $key, $group, $multiline);
+            add_action('admin_notices', function() {
+                printf('<div class="notice notice-error"><p>Please <a href="%s">activate</a> the Polylang plugin and configure it with at least one <a href="%s">language</a>.</p></div>', admin_url('plugins.php'), admin_url('admin.php?page=mlang'));
+            });
+        } else {
+            foreach ($groups as $group => $translations) {
+                foreach ($translations as $key => $description) {
+                    pll_register_string($description, $key, $group, $multiline);
+                }
             }
         }
     }
@@ -43,20 +43,24 @@ if (!function_exists('trans')) {
      * @param string $key
      * @param string|null $lang
      *
-     * @throws \BadFunctionCallException
-     *
      * @return string
      */
     function trans(string $key, string $lang = null): string
     {
-        if (!function_exists('pll__')) {
-            throw new BadFunctionCallException('Please activate the Polylang plugin and configure it with at least one language.');
+        if (!function_exists('pll__') || !function_exists('pll_translate_string')) {
+            add_action('admin_notices', function() {
+                printf('<div class="notice notice-error"><p>Please <a href="%s">activate</a> the Polylang plugin and configure it with at least one <a href="%s">language</a>.</p></div>', admin_url('plugins.php'), admin_url('admin.php?page=mlang'));
+            });
         }
 
-        if ($lang) {
+        if (function_exists('pll_translate_string') && $lang) {
             return pll_translate_string($key, $lang);
         }
 
-        return pll__($key);
+        if (function_exists('pll__')) {
+            return pll__($key);
+        }
+
+        return __($key);
     }
 }


### PR DESCRIPTION
Add "admin notice" instead of throwing an exception that sometimes prevent admin adding a language, specific case with "/wp-admin" rewritten to something else using iThemes Security.