### PR TITLE
Change Polylang from "require" to "suggest"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3"
+    },
+    "suggest": {
         "wpackagist-plugin/polylang": "^2.2"
     },
     "require-dev": {


### PR DESCRIPTION
Maybe this is a breaking change, but it allow helper functions to work with Polylang PRO.
But you have to install Polylang or Polylang PRO yourself.